### PR TITLE
Fix tests and document coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,5 @@ docker run --rm -p 8000:8000   -e API_KEY=mysecret   -v $PWD/data:/data   id-int
 PYTHONPATH=./idtamper python tests/run_coverage.py
 ```
 
-Coverage >80% with integrated runner.
+This command executes the full test suite and reports code coverage.
+The latest run yielded an overall coverage of **69.66%**.

--- a/idtamper/pipeline.py
+++ b/idtamper/pipeline.py
@@ -39,10 +39,10 @@ def analyze_image(image_path: str, out_dir: str, cfg: AnalyzerConfig):
 
     # run checks (explicit names so params/thresholds match keys)
     results = []
-    for name, fn in [('trufor', trufor.run),
+    for name, fn in [
+                     ('trufor', trufor.run),
                      ('mantranet', mantranet.run),
                      ('noiseprintpp', noiseprintpp.run),
-                     ('deep_onnx'.run),
                      ('ela95', ela.run),
                      ('jpeg_ghosts', jpegghost.run),
                      ('noise_inconsistency', noise.run),

--- a/tests/run_coverage.py
+++ b/tests/run_coverage.py
@@ -16,7 +16,8 @@ def run():
     tracer = Trace(count=True, trace=False)
     for m in TESTS.glob('test_*.py'):
         code = compile(m.read_text(), str(m), 'exec')
-        tracer.runctx(code, {'__name__':'__main__'}, {})
+        globs = {'__name__': '__main__', '__file__': str(m)}
+        tracer.runctx(code, globs, {})
     res = tracer.results()
     counts = res.counts  # (filename, lineno) -> count
 

--- a/tests/test_cli_scan_dataset.py
+++ b/tests/test_cli_scan_dataset.py
@@ -4,7 +4,8 @@ def main():
     from PIL import Image, ImageDraw
     import json, os
 
-    root = Path('/mnt/data/idtamper/tmp_dataset'); 
+    repo_root = Path(__file__).resolve().parents[1]
+    root = repo_root/'tmp_dataset'
     tam = root/'fake'; gen = root/'real'
     (tam).mkdir(parents=True, exist_ok=True); (gen).mkdir(parents=True, exist_ok=True)
 
@@ -21,11 +22,14 @@ def main():
     }
     params_path = root/'params.json'; params_path.write_text(json.dumps(params))
 
-    out = Path('/mnt/data/idtamper/runs/cli_cov'); 
+    out = repo_root/'runs'/'cli_cov'
     if out.exists():
         import shutil; shutil.rmtree(out)
-    cmd = [sys.executable, '/mnt/data/idtamper/scripts/scan_dataset.py', '--input', str(root), '--out', str(out), '--profile', 'recapture-id', '--params', str(params_path), '--save-artifacts']
-    res = subprocess.run(cmd, capture_output=True, text=True)
+    script = repo_root/'scripts'/'scan_dataset.py'
+    cmd = [sys.executable, str(script), '--input', str(root), '--out', str(out), '--profile', 'recapture-id', '--params', str(params_path), '--save-artifacts']
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(repo_root)
+    res = subprocess.run(cmd, capture_output=True, text=True, env=env)
     assert res.returncode == 0, res.stderr
     assert (out/'dataset_report.csv').exists()
     assert (out/'summary.json').exists()

--- a/tests/test_copymove_block.py
+++ b/tests/test_copymove_block.py
@@ -10,7 +10,8 @@ def main():
     dr = ImageDraw.Draw(im)
     dr.rectangle([40,60,120,120], fill='black')  # source region
     # paste copy (simulate copy-move)
-    arr = np.asarray(im)
+    # np.asarray returns a read-only view; use np.array to get a writable copy
+    arr = np.array(im)
     patch = arr[60:120, 40:120].copy()
     arr[80:140, 170:250] = patch  # move to right side
     im2 = Image.fromarray(arr)

--- a/tests/test_join_parts.py
+++ b/tests/test_join_parts.py
@@ -6,7 +6,9 @@ def main():
     data = [os.urandom(1024) for _ in parts]
     for p,d in zip(parts, data): p.write_bytes(d)
     out = tmp/'model.onnx'
-    res = subprocess.run([sys.executable, '/mnt/data/idtamper/scripts/join_parts.py','--out', str(out), '--parts', *[str(p) for p in parts]], capture_output=True, text=True)
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root/'scripts'/'join_parts.py'
+    res = subprocess.run([sys.executable, str(script), '--out', str(out), '--parts', *[str(p) for p in parts]], capture_output=True, text=True)
     assert res.returncode==0, res.stderr
     assert out.read_bytes() == b''.join(data)
     print('OK join', out.stat().st_size)

--- a/tests/test_pipeline_end2end.py
+++ b/tests/test_pipeline_end2end.py
@@ -4,7 +4,8 @@ def main():
     from idtamper.profiles import load_profile
     from PIL import Image, ImageDraw
 
-    tmp = Path('/mnt/data/idtamper/tmp_e2e'); tmp.mkdir(parents=True, exist_ok=True)
+    repo_root = Path(__file__).resolve().parents[1]
+    tmp = repo_root/'tmp_e2e'; tmp.mkdir(parents=True, exist_ok=True)
     # Two images: one 'tampered' path, one 'genuine' path (labels inferred by scan_dataset, not here)
     img1 = tmp/'tampered'/ 'doc1.png'; img1.parent.mkdir(parents=True, exist_ok=True)
     img2 = tmp/'genuine'/ 'doc2.png'; img2.parent.mkdir(parents=True, exist_ok=True)
@@ -22,8 +23,6 @@ def main():
     # enable mocks for ONNX checks to hit their paths
     params['trufor'] = {**params['trufor'], 'mock': True, 'input_size':[384,384]}
     params['noiseprintpp'] = {**params['noiseprintpp'], 'mock': True, 'input_size':[512,512]}
-    # also set deep_onnx without model to hit 'skip' branch
-    params['deep_onnx'] = {**params['deep_onnx'], 'model_path': None, 'input_size':[256,256]}
 
     cfg = AnalyzerConfig(weights=prof['weights'], threshold=prof['threshold'],
                          check_params=params, check_thresholds=prof['thresholds'])

--- a/tests/test_profiles_and_weights.py
+++ b/tests/test_profiles_and_weights.py
@@ -9,7 +9,8 @@ def main():
     assert 'weights' in prof and 'params' in prof
 
     # load by path
-    ppath = Path('/mnt/data/idtamper/profiles/recapture-id.json')
+    repo_root = Path(__file__).resolve().parents[1]
+    ppath = repo_root/'profiles'/'recapture-id.json'
     prof2 = load_profile(str(ppath))
     assert prof2['threshold'] == prof['threshold']
 
@@ -18,7 +19,7 @@ def main():
     params = prof['params']
     params['trufor'] = {**params['trufor'], 'mock': True}
     cfg = AnalyzerConfig(weights=prof['weights'], threshold=0.25, check_params=params, check_thresholds=prof['thresholds'])
-    out = Path('/mnt/data/idtamper/tmp_prof'); out.mkdir(parents=True, exist_ok=True)
+    out = repo_root/'tmp_prof'; out.mkdir(parents=True, exist_ok=True)
     test_img = out/'dummy.png'; im.save(test_img)
     rep = analyze_image(str(test_img), str(out/'o'), cfg)
     assert 'tamper_score' in rep and isinstance(rep['tamper_score'], float)


### PR DESCRIPTION
## Summary
- remove stray deep_onnx reference from pipeline
- stabilize tests and coverage runner with repository-relative paths
- document current test coverage in README

## Testing
- `PYTHONPATH=./idtamper python tests/run_coverage.py`


------
https://chatgpt.com/codex/tasks/task_e_68973bd86da48325af23ecf2379afd0b