### PR TITLE
feat(web): expose detailed report info

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Response: JSON with scores, confidence, per-check details, artifact paths.
 
 ---
 
+## Web Viewer
+
+The `web/` folder contains a React + Ant Design front-end that calls the REST API and renders the full report: per-check scores, thresholds, weights, contributions and descriptions, all generated artifacts with a legend, and the final tamper score with its formula. See [`web/README.md`](web/README.md) for setup instructions (`npm run dev`).
+
+---
+
 ## Docker Usage
 
 ```bash

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # ID Integrity Shield — Viewer (React + Vite + Ant Design)
 
-Un'app leggera per vedere in azione lo SDK: carichi **una sola immagine**, avvii l'analisi, e visualizzi **verdetto**, **punteggi/soglie**, **heatmap/overlay** e una **descrizione testuale**.
+Un'app leggera per vedere in azione lo SDK: carichi **una sola immagine**, avvii l'analisi e visualizzi **tutti i dati del report**: verdetto con soglia, tabella dei singoli check (score, soglia, peso, contributo e spiegazione), **artefatti** con legenda e **descrizione testuale**.
 
 ## Requisiti
 - Node.js 18+
@@ -56,7 +56,8 @@ Le chiavi `heatmap`/`overlay` possono essere URL assoluti oppure percorsi; se il
 ## UI
 - **Dropzone (singolo file)** con Upload.Dragger
 - **Loader** (Spin) durante l'analisi
-- **Verdetto + progress** del tamper score
-- **Tab visuali**: originale | heatmap/overlay (preview-group)
-- **Tabella dettagli** per check (score, soglia, peso, decisione)
+- **Verdetto + progress** del tamper score e soglia finale
+- **Tab artefatti** con anteprima di tutte le immagini generate e legenda
+- **Tabella dettagli** per check (score, soglia, peso, contributo, esito, descrizione)
+- **Formula** del tamper score mostrata sotto la tabella
 - **Descrizione testuale** autogenerata

--- a/web/src/components/AnalysisView.tsx
+++ b/web/src/components/AnalysisView.tsx
@@ -1,89 +1,208 @@
 import React from 'react'
 import type { SdkReport } from '../types'
-import { Card, Descriptions, Progress, Tag, Tabs, Image, Typography, Space, Table } from 'antd'
+import { Card, Descriptions, Progress, Tag, Tabs, Image, Typography, Space, Table, Tooltip } from 'antd'
 import { resolveArtifactUrl } from '../api'
 import { verdictFromReport, summarize } from '../utils'
 
-type Props = { fileUrl: string; report: SdkReport }
+ type Props = { fileUrl: string; report: SdkReport }
 
-function CheckTag({ ok }: { ok: boolean | undefined }) {
-  if (ok === undefined) return <Tag>n/d</Tag>
-  return ok ? <Tag color="red">sospetto</Tag> : <Tag color="green">ok</Tag>
-}
+ function CheckTag({ ok }: { ok: boolean | undefined }) {
+   if (ok === undefined) return <Tag>n/d</Tag>
+   return ok ? <Tag color="red">sospetto</Tag> : <Tag color="green">ok</Tag>
+ }
 
-export default function AnalysisView({ fileUrl, report }: Props) {
-  const v = verdictFromReport(report)
-  const checks = Object.entries(report.checks || {})
-  const columns = [
-    { title: 'Check', dataIndex: 'name', key: 'name' },
-    { title: 'Score', dataIndex: 'score', key: 'score', render: (v:number|undefined) => v!=null ? v.toFixed(3) : 'n/d' },
-    { title: 'Soglia', dataIndex: 'threshold', key: 'threshold', render: (v:number|undefined) => v!=null ? v.toFixed(2) : 'n/d' },
-    { title: 'Peso', dataIndex: 'weight', key: 'weight', render: (v:number|undefined) => v!=null ? v.toFixed(2) : 'n/d' },
-    { title: 'Esito', dataIndex: 'decision', key: 'decision', render: (d:boolean|undefined) => <CheckTag ok={d}/> },
-  ]
-  const data = checks.map(([name, c]) => ({ key: name, name, score: c?.score, threshold: c?.threshold, weight: c?.weight, decision: c?.decision }))
+ export default function AnalysisView({ fileUrl, report }: Props) {
+   const v = verdictFromReport(report)
+   const checks = Object.entries(report.checks || {})
 
-  const globalArtifacts: string[] = []
-  if (report.artifacts) {
-    for (const [, v] of Object.entries(report.artifacts)) {
-      if (typeof v === 'string') globalArtifacts.push(resolveArtifactUrl(v))
-    }
-  }
-  const heatmaps: Array<{label:string,url:string}> = []
-  checks.forEach(([name, c]) => {
-    const arts = (c?.artifacts || {}) as Record<string,string>
-    Object.entries(arts).forEach(([k, v]) => {
-      if (/heatmap|overlay|mask/i.test(k)) heatmaps.push({ label: `${name}:${k}`, url: resolveArtifactUrl(v) })
-    })
-  })
+   const CHECK_DESCRIPTIONS: Record<string, string> = {
+     mantranet: 'Rete neurale che evidenzia manipolazioni pixel-level',
+     noiseprintpp: 'Analisi della firma di rumore della fotocamera',
+     jpeg_ghost: 'Rileva ricompressioni JPEG differenti',
+     ela: 'Error Level Analysis: evidenzia aree ricampionate',
+     blockiness: 'Controllo discontinuità dei blocchi JPEG',
+     copy_move: 'Ricerca regioni duplicate (copy-move)',
+     splicing: 'Analizza incoerenze tra porzioni incollate',
+     noise: 'Valuta incoerenze di rumore',
+     exif: 'Verifica coerenza dei metadati EXIF',
+   }
 
-  const narrative = summarize(report)
+   const ARTIFACT_DESCRIPTIONS: Record<string, string> = {
+     heatmap: 'Heatmap: intensità del sospetto (rosso=alto)',
+     overlay: "Overlay: aree sospette sovrapposte all'originale",
+     fused_heatmap: 'Heatmap fusa di tutti i controlli',
+     mask: 'Maschera binaria delle zone sospette',
+   }
 
-  return (
-    <Space direction="vertical" size={16} style={{ width:'100%' }}>
-      <Card className="card" title={<Typography.Text style={{color:'white'}}>Verdetto</Typography.Text>}>
-        <Space direction="vertical" size={12} style={{ width:'100%' }}>
-          <Space align="center" wrap>
-            <Typography.Title level={3} style={{color:'white', margin:0}}>
-              {v.verdict === 'TAMPERED' ? 'TAMPERED' : v.verdict === 'CLEAN' ? 'CLEAN' : 'Sconosciuto'}
-            </Typography.Title>
-            {typeof report.tamper_score === 'number' &&
-              <Progress percent={Math.round(report.tamper_score*100)} steps={12} showInfo format={() => `score ${report.tamper_score?.toFixed(3)}`} />}
-          </Space>
-          <Descriptions bordered column={2} size="small" style={{ background:'transparent' }}
-            items={[
-              { key:'prof', label:'Profilo', children: report.profile_id || 'n/d' },
-              { key:'thr', label:'Soglia', children: v.threshold != null ? v.threshold.toFixed(2) : 'n/d' },
-              { key:'conf', label:'Confidenza', children: report.confidence != null ? `${Math.round((report.confidence||0)*100)}%` : 'n/d' },
-              { key:'version', label:'Versione', children: (report.version || report.runtime?.git || 'n/d') }
-            ]}
-          />
-        </Space>
-      </Card>
+   const columns = [
+     {
+       title: 'Check',
+       dataIndex: 'name',
+       key: 'name',
+       render: (n: string) => (
+         <Tooltip title={CHECK_DESCRIPTIONS[n] || 'n/d'}>
+           <span>{n}</span>
+         </Tooltip>
+       ),
+     },
+     { title: 'Score', dataIndex: 'score', key: 'score', render: (v:number|undefined) => v!=null ? v.toFixed(3) : 'n/d' },
+     { title: 'Soglia', dataIndex: 'threshold', key: 'threshold', render: (v:number|undefined) => v!=null ? v.toFixed(2) : 'n/d' },
+     { title: 'Peso', dataIndex: 'weight', key: 'weight', render: (v:number|undefined) => v!=null ? v.toFixed(2) : 'n/d' },
+     { title: 'Contributo', dataIndex: 'contribution', key: 'contribution', render: (v:number|undefined) => v!=null ? v.toFixed(3) : 'n/d' },
+     { title: 'Esito', dataIndex: 'decision', key: 'decision', render: (d:boolean|undefined) => <CheckTag ok={d}/> },
+     { title: 'Descrizione', dataIndex: 'description', key: 'description' },
+   ]
 
-      <Card className="card" title={<Typography.Text style={{color:'white'}}>Confronto visivo</Typography.Text>}>
-        <Tabs
-          items={[
-            { key:'orig', label:'Originale', children: <Image src={fileUrl} alt="originale" /> },
-            ...heatmaps.length ? [{ key:'hm', label:`Heatmap/Overlay (${heatmaps.length})`, children: (
-                <Image.PreviewGroup>
-                  <Space size={[12,12]} wrap>
-                    {heatmaps.map((h, i) => <Image key={i} width={360} src={h.url} alt={h.label} />)}
-                    {globalArtifacts.map((u, i) => <Image key={'g'+i} width={360} src={u} alt={'artifact '+i} />)}
-                  </Space>
-                </Image.PreviewGroup>
-            ) }] : []
-          ]}
-        />
-      </Card>
+   const data = checks.map(([name, c]) => {
+     const score = c?.score ?? 0
+     const weight = c?.weight ?? 0
+     return {
+       key: name,
+       name,
+       score: c?.score,
+       threshold: c?.threshold,
+       weight: c?.weight,
+       contribution: score * weight,
+       decision: c?.decision,
+       description: CHECK_DESCRIPTIONS[name] || '-',
+     }
+   })
 
-      <Card className="card" title={<Typography.Text style={{color:'white'}}>Dettaglio controlli</Typography.Text>}>
-        <Table columns={columns} dataSource={data} pagination={false} />
-      </Card>
+   const artifacts: Array<{ label: string; url: string; isImage: boolean; type: string }> = []
+   const artifactKeys = new Set<string>()
 
-      <Card className="card" title={<Typography.Text style={{color:'white'}}>Descrizione testuale</Typography.Text>}>
-        <Typography.Paragraph style={{whiteSpace:'pre-wrap', color:'white'}}>{narrative}</Typography.Paragraph>
-      </Card>
-    </Space>
-  )
-}
+   if (report.artifacts) {
+     for (const [k, v] of Object.entries(report.artifacts)) {
+       if (typeof v === 'string') {
+         const url = resolveArtifactUrl(v)
+         const isImage = /\.png$|\.jpg$|\.jpeg$|\.gif$|\.webp$/i.test(v)
+         artifacts.push({ label: `global:${k}`, url, isImage, type: k })
+         artifactKeys.add(k)
+       }
+     }
+   }
+
+   checks.forEach(([name, c]) => {
+     const arts = (c?.artifacts || {}) as Record<string, string>
+     Object.entries(arts).forEach(([k, v]) => {
+       if (typeof v === 'string') {
+         const url = resolveArtifactUrl(v)
+         const isImage = /\.png$|\.jpg$|\.jpeg$|\.gif$|\.webp$/i.test(v)
+         artifacts.push({ label: `${name}:${k}`, url, isImage, type: k })
+         artifactKeys.add(k)
+       }
+     })
+   })
+
+   const imageArtifacts = artifacts.filter(a => a.isImage)
+   const otherArtifacts = artifacts.filter(a => !a.isImage)
+
+   const narrative = summarize(report)
+
+   const weightSum = data.reduce((s, d) => s + (d.weight ?? 0), 0)
+   const weighted = data.reduce((s, d) => s + (d.contribution ?? 0), 0)
+   const calcScore = weightSum ? weighted / weightSum : undefined
+
+   const legendItems = Array.from(artifactKeys).map(k => ({
+     key: k,
+     label: k,
+     children: ARTIFACT_DESCRIPTIONS[k] || '-',
+   }))
+
+   return (
+     <Space direction="vertical" size={16} style={{ width: '100%' }}>
+       <Card className="card" title={<Typography.Text style={{ color: 'white' }}>Verdetto</Typography.Text>}>
+         <Space direction="vertical" size={12} style={{ width: '100%' }}>
+           <Space align="center" wrap>
+             <Typography.Title level={3} style={{ color: 'white', margin: 0 }}>
+               {v.verdict === 'TAMPERED' ? 'TAMPERED' : v.verdict === 'CLEAN' ? 'CLEAN' : 'Sconosciuto'}
+             </Typography.Title>
+             {typeof report.tamper_score === 'number' && (
+               <Progress
+                 percent={Math.round(report.tamper_score * 100)}
+                 steps={12}
+                 showInfo
+                 format={() => `score ${report.tamper_score?.toFixed(3)}`}
+               />
+             )}
+           </Space>
+           <Descriptions
+             bordered
+             column={2}
+             size="small"
+             style={{ background: 'transparent' }}
+             items={[
+               { key: 'prof', label: 'Profilo', children: report.profile_id || 'n/d' },
+               { key: 'score', label: 'Score finale', children: report.tamper_score != null ? report.tamper_score.toFixed(3) : 'n/d' },
+               { key: 'thr', label: 'Soglia', children: v.threshold != null ? v.threshold.toFixed(2) : 'n/d' },
+               { key: 'conf', label: 'Confidenza', children: report.confidence != null ? `${Math.round((report.confidence||0)*100)}%` : 'n/d' },
+               { key: 'version', label: 'Versione', children: report.version || report.runtime?.git || 'n/d' },
+             ]}
+           />
+         </Space>
+       </Card>
+
+       <Card className="card" title={<Typography.Text style={{ color: 'white' }}>Confronto visivo</Typography.Text>}>
+         <Tabs
+           items={[
+             { key: 'orig', label: 'Originale', children: <Image src={fileUrl} alt="originale" /> },
+             ...artifacts.length
+               ? [
+                   {
+                     key: 'art',
+                     label: `Artefatti (${artifacts.length})`,
+                     children: (
+                       <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                         {imageArtifacts.length > 0 && (
+                           <Image.PreviewGroup>
+                             <Space size={[12, 12]} wrap>
+                               {imageArtifacts.map((a, i) => (
+                                 <div key={i} style={{ textAlign: 'center' }}>
+                                   <Image width={360} src={a.url} alt={a.label} />
+                                   <Typography.Text style={{ color: 'white' }}>{a.label}</Typography.Text>
+                                 </div>
+                               ))}
+                             </Space>
+                           </Image.PreviewGroup>
+                         )}
+                         {otherArtifacts.length > 0 && (
+                           <Space direction="vertical" size={4}>
+                             {otherArtifacts.map((a, i) => (
+                               <Typography.Link key={i} href={a.url} target="_blank">
+                                 {a.label}
+                               </Typography.Link>
+                             ))}
+                           </Space>
+                         )}
+                         {legendItems.length > 0 && (
+                           <Descriptions
+                             size="small"
+                             column={1}
+                             style={{ background: 'transparent' }}
+                             labelStyle={{ color: 'white' }}
+                             contentStyle={{ color: 'white' }}
+                             items={legendItems}
+                           />
+                         )}
+                       </Space>
+                     ),
+                   },
+                 ]
+               : [],
+           ]}
+         />
+       </Card>
+
+       <Card className="card" title={<Typography.Text style={{ color: 'white' }}>Dettaglio controlli</Typography.Text>}>
+         <Table columns={columns} dataSource={data} pagination={false} scroll={{ x: true }} />
+         <Typography.Paragraph style={{ color: 'white', marginTop: 12 }}>
+           Tamper score = Σ(score × peso) / Σ(pesi) = {calcScore != null ? calcScore.toFixed(3) : 'n/d'}
+         </Typography.Paragraph>
+       </Card>
+
+       <Card className="card" title={<Typography.Text style={{ color: 'white' }}>Descrizione testuale</Typography.Text>}>
+         <Typography.Paragraph style={{ whiteSpace: 'pre-wrap', color: 'white' }}>{narrative}</Typography.Paragraph>
+       </Card>
+     </Space>
+   )
+ }


### PR DESCRIPTION
## Summary
- Show per-check score, threshold, weight and contribution with descriptions
- Display all generated artifacts with legends and final score formula
- Document web viewer capabilities and setup

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ca0f565c832580a4c58f46ff4140